### PR TITLE
Use ZGC instead of ConcMarkSweepGC, and Coredump over Minidump

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -14,6 +14,9 @@
       <option name="JD_DO_NOT_WRAP_ONE_LINE_COMMENTS" value="true" />
       <option name="JD_INDENT_ON_CONTINUATION" value="true" />
     </JavaCodeStyleSettings>
+    <ScalaCodeStyleSettings>
+      <option name="MULTILINE_STRING_CLOSING_QUOTES_ON_NEW_LINE" value="true" />
+    </ScalaCodeStyleSettings>
     <editorconfig>
       <option name="ENABLED" value="false" />
     </editorconfig>

--- a/src/functionalTest/resources/Debug_Zomboid.xml
+++ b/src/functionalTest/resources/Debug_Zomboid.xml
@@ -2,7 +2,7 @@
     <configuration default="false" factoryName="Application" name="Debug Zomboid" type="Application">
         <option name="MAIN_CLASS_NAME" value="zombie.gameStates.MainScreenState"/>
         <module name="testLaunchRunConfigs.main"/>
-        <option name="VM_PARAMETERS" value="-Ddebug -Dzomboid.steam=1 -Dzomboid.znetlog=1 -XX:+UseConcMarkSweepGC -XX:-CreateMinidumpOnCrash -XX:-OmitStackTraceInFastThrow -Xms1800m -Xmx2048m"/>
+        <option name="VM_PARAMETERS" value="-Ddebug -Dzomboid.steam=1 -Dzomboid.znetlog=1 -XX:+UseZGC -XX:-CreateCoredumpOnCrash -XX:-OmitStackTraceInFastThrow -Xms1800m -Xmx2048m"/>
         <option name="WORKING_DIRECTORY" value="build/tmp/functionalTest/testLaunchRunConfigs/gameDir"/>
         <method v="2">
             <option enabled="true" externalProjectPath="$PROJECT_DIR$" name="Gradle.BeforeRunTask" scriptParameters="" tasks="zomboidClasses" vmOptions=""/>

--- a/src/functionalTest/resources/Debug_Zomboid_linux.xml
+++ b/src/functionalTest/resources/Debug_Zomboid_linux.xml
@@ -2,7 +2,7 @@
     <configuration default="false" factoryName="Application" name="Debug Zomboid" type="Application">
         <option name="MAIN_CLASS_NAME" value="zombie.gameStates.MainScreenState"/>
         <module name="testLaunchRunConfigs.main"/>
-        <option name="VM_PARAMETERS" value="-Ddebug -Dzomboid.steam=1 -Dzomboid.znetlog=1 -XX:+UseConcMarkSweepGC -XX:-CreateMinidumpOnCrash -XX:-OmitStackTraceInFastThrow -Xms1800m -Xmx2048m -Djava.library.path=build/tmp/functionalTest/testLaunchRunConfigs/gameDir:build/tmp/functionalTest/testLaunchRunConfigs/gameDir/linux64:build/tmp/functionalTest/testLaunchRunConfigs/gameDir/jre64/lib/amd64 -Dorg.lwjgl.librarypath=build/tmp/functionalTest/testLaunchRunConfigs/gameDir"/>
+        <option name="VM_PARAMETERS" value="-Ddebug -Dzomboid.steam=1 -Dzomboid.znetlog=1 -XX:+UseZGC -XX:-CreateCoredumpOnCrash -XX:-OmitStackTraceInFastThrow -Xms1800m -Xmx2048m -Djava.library.path=build/tmp/functionalTest/testLaunchRunConfigs/gameDir:build/tmp/functionalTest/testLaunchRunConfigs/gameDir/linux64:build/tmp/functionalTest/testLaunchRunConfigs/gameDir/jre64/lib/amd64 -Dorg.lwjgl.librarypath=build/tmp/functionalTest/testLaunchRunConfigs/gameDir"/>
         <option name="WORKING_DIRECTORY" value="build/tmp/functionalTest/testLaunchRunConfigs/gameDir"/>
         <method v="2">
             <option enabled="true" externalProjectPath="$PROJECT_DIR$" name="Gradle.BeforeRunTask" scriptParameters="" tasks="zomboidClasses" vmOptions=""/>

--- a/src/functionalTest/resources/Debug_Zomboid_local.xml
+++ b/src/functionalTest/resources/Debug_Zomboid_local.xml
@@ -2,7 +2,7 @@
     <configuration default="false" factoryName="Application" name="Debug Zomboid (local)" type="Application">
         <option name="MAIN_CLASS_NAME" value="zombie.gameStates.MainScreenState"/>
         <module name="testLaunchRunConfigs.main"/>
-        <option name="VM_PARAMETERS" value="-Ddebug -Dzomboid.steam=0 -Dzomboid.znetlog=1 -XX:+UseConcMarkSweepGC -XX:-CreateMinidumpOnCrash -XX:-OmitStackTraceInFastThrow -Xms1800m -Xmx2048m"/>
+        <option name="VM_PARAMETERS" value="-Ddebug -Dzomboid.steam=0 -Dzomboid.znetlog=1 -XX:+UseZGC -XX:-CreateCoredumpOnCrash -XX:-OmitStackTraceInFastThrow -Xms1800m -Xmx2048m"/>
         <option name="WORKING_DIRECTORY" value="build/tmp/functionalTest/testLaunchRunConfigs/gameDir"/>
         <method v="2">
             <option enabled="true" externalProjectPath="$PROJECT_DIR$" name="Gradle.BeforeRunTask" scriptParameters="" tasks="zomboidClasses" vmOptions=""/>

--- a/src/functionalTest/resources/Debug_Zomboid_local_linux.xml
+++ b/src/functionalTest/resources/Debug_Zomboid_local_linux.xml
@@ -2,7 +2,7 @@
     <configuration default="false" factoryName="Application" name="Debug Zomboid (local)" type="Application">
         <option name="MAIN_CLASS_NAME" value="zombie.gameStates.MainScreenState"/>
         <module name="testLaunchRunConfigs.main"/>
-        <option name="VM_PARAMETERS" value="-Ddebug -Dzomboid.steam=0 -Dzomboid.znetlog=1 -XX:+UseConcMarkSweepGC -XX:-CreateMinidumpOnCrash -XX:-OmitStackTraceInFastThrow -Xms1800m -Xmx2048m -Djava.library.path=build/tmp/functionalTest/testLaunchRunConfigs/gameDir:build/tmp/functionalTest/testLaunchRunConfigs/gameDir/linux64:build/tmp/functionalTest/testLaunchRunConfigs/gameDir/jre64/lib/amd64 -Dorg.lwjgl.librarypath=build/tmp/functionalTest/testLaunchRunConfigs/gameDir"/>
+        <option name="VM_PARAMETERS" value="-Ddebug -Dzomboid.steam=0 -Dzomboid.znetlog=1 -XX:+UseZGC -XX:-CreateCoredumpOnCrash -XX:-OmitStackTraceInFastThrow -Xms1800m -Xmx2048m -Djava.library.path=build/tmp/functionalTest/testLaunchRunConfigs/gameDir:build/tmp/functionalTest/testLaunchRunConfigs/gameDir/linux64:build/tmp/functionalTest/testLaunchRunConfigs/gameDir/jre64/lib/amd64 -Dorg.lwjgl.librarypath=build/tmp/functionalTest/testLaunchRunConfigs/gameDir"/>
         <option name="WORKING_DIRECTORY" value="build/tmp/functionalTest/testLaunchRunConfigs/gameDir"/>
         <method v="2">
             <option enabled="true" externalProjectPath="$PROJECT_DIR$" name="Gradle.BeforeRunTask" scriptParameters="" tasks="zomboidClasses" vmOptions=""/>

--- a/src/functionalTest/resources/Run_Zomboid.xml
+++ b/src/functionalTest/resources/Run_Zomboid.xml
@@ -2,7 +2,7 @@
     <configuration default="false" factoryName="Application" name="Run Zomboid" type="Application">
         <option name="MAIN_CLASS_NAME" value="zombie.gameStates.MainScreenState"/>
         <module name="testLaunchRunConfigs.main"/>
-        <option name="VM_PARAMETERS" value="-Dzomboid.steam=1 -Dzomboid.znetlog=1 -XX:+UseConcMarkSweepGC -XX:-CreateMinidumpOnCrash -XX:-OmitStackTraceInFastThrow -Xms1800m -Xmx2048m"/>
+        <option name="VM_PARAMETERS" value="-Dzomboid.steam=1 -Dzomboid.znetlog=1 -XX:+UseZGC -XX:-CreateCoredumpOnCrash -XX:-OmitStackTraceInFastThrow -Xms1800m -Xmx2048m"/>
         <option name="WORKING_DIRECTORY" value="build/tmp/functionalTest/testLaunchRunConfigs/gameDir"/>
         <method v="2">
             <option enabled="true" externalProjectPath="$PROJECT_DIR$" name="Gradle.BeforeRunTask" scriptParameters="" tasks="zomboidClasses" vmOptions=""/>

--- a/src/functionalTest/resources/Run_Zomboid_linux.xml
+++ b/src/functionalTest/resources/Run_Zomboid_linux.xml
@@ -2,7 +2,7 @@
     <configuration default="false" factoryName="Application" name="Run Zomboid" type="Application">
         <option name="MAIN_CLASS_NAME" value="zombie.gameStates.MainScreenState"/>
         <module name="testLaunchRunConfigs.main"/>
-        <option name="VM_PARAMETERS" value="-Dzomboid.steam=1 -Dzomboid.znetlog=1 -XX:+UseConcMarkSweepGC -XX:-CreateMinidumpOnCrash -XX:-OmitStackTraceInFastThrow -Xms1800m -Xmx2048m -Djava.library.path=build/tmp/functionalTest/testLaunchRunConfigs/gameDir:build/tmp/functionalTest/testLaunchRunConfigs/gameDir/linux64:build/tmp/functionalTest/testLaunchRunConfigs/gameDir/jre64/lib/amd64 -Dorg.lwjgl.librarypath=build/tmp/functionalTest/testLaunchRunConfigs/gameDir"/>
+        <option name="VM_PARAMETERS" value="-Dzomboid.steam=1 -Dzomboid.znetlog=1 -XX:+UseZGC -XX:-CreateCoredumpOnCrash -XX:-OmitStackTraceInFastThrow -Xms1800m -Xmx2048m -Djava.library.path=build/tmp/functionalTest/testLaunchRunConfigs/gameDir:build/tmp/functionalTest/testLaunchRunConfigs/gameDir/linux64:build/tmp/functionalTest/testLaunchRunConfigs/gameDir/jre64/lib/amd64 -Dorg.lwjgl.librarypath=build/tmp/functionalTest/testLaunchRunConfigs/gameDir"/>
         <option name="WORKING_DIRECTORY" value="build/tmp/functionalTest/testLaunchRunConfigs/gameDir"/>
         <method v="2">
             <option enabled="true" externalProjectPath="$PROJECT_DIR$" name="Gradle.BeforeRunTask" scriptParameters="" tasks="zomboidClasses" vmOptions=""/>

--- a/src/functionalTest/resources/Run_Zomboid_local.xml
+++ b/src/functionalTest/resources/Run_Zomboid_local.xml
@@ -2,7 +2,7 @@
     <configuration default="false" factoryName="Application" name="Run Zomboid (local)" type="Application">
         <option name="MAIN_CLASS_NAME" value="zombie.gameStates.MainScreenState"/>
         <module name="testLaunchRunConfigs.main"/>
-        <option name="VM_PARAMETERS" value="-Dzomboid.steam=0 -Dzomboid.znetlog=1 -XX:+UseConcMarkSweepGC -XX:-CreateMinidumpOnCrash -XX:-OmitStackTraceInFastThrow -Xms1800m -Xmx2048m"/>
+        <option name="VM_PARAMETERS" value="-Dzomboid.steam=0 -Dzomboid.znetlog=1 -XX:+UseZGC -XX:-CreateCoredumpOnCrash -XX:-OmitStackTraceInFastThrow -Xms1800m -Xmx2048m"/>
         <option name="WORKING_DIRECTORY" value="build/tmp/functionalTest/testLaunchRunConfigs/gameDir"/>
         <method v="2">
             <option enabled="true" externalProjectPath="$PROJECT_DIR$" name="Gradle.BeforeRunTask" scriptParameters="" tasks="zomboidClasses" vmOptions=""/>

--- a/src/functionalTest/resources/Run_Zomboid_local_linux.xml
+++ b/src/functionalTest/resources/Run_Zomboid_local_linux.xml
@@ -2,7 +2,7 @@
     <configuration default="false" factoryName="Application" name="Run Zomboid (local)" type="Application">
         <option name="MAIN_CLASS_NAME" value="zombie.gameStates.MainScreenState"/>
         <module name="testLaunchRunConfigs.main"/>
-        <option name="VM_PARAMETERS" value="-Dzomboid.steam=0 -Dzomboid.znetlog=1 -XX:+UseConcMarkSweepGC -XX:-CreateMinidumpOnCrash -XX:-OmitStackTraceInFastThrow -Xms1800m -Xmx2048m -Djava.library.path=build/tmp/functionalTest/testLaunchRunConfigs/gameDir:build/tmp/functionalTest/testLaunchRunConfigs/gameDir/linux64:build/tmp/functionalTest/testLaunchRunConfigs/gameDir/jre64/lib/amd64 -Dorg.lwjgl.librarypath=build/tmp/functionalTest/testLaunchRunConfigs/gameDir"/>
+        <option name="VM_PARAMETERS" value="-Dzomboid.steam=0 -Dzomboid.znetlog=1 -XX:+UseZGC -XX:-CreateCoredumpOnCrash -XX:-OmitStackTraceInFastThrow -Xms1800m -Xmx2048m -Djava.library.path=build/tmp/functionalTest/testLaunchRunConfigs/gameDir:build/tmp/functionalTest/testLaunchRunConfigs/gameDir/linux64:build/tmp/functionalTest/testLaunchRunConfigs/gameDir/jre64/lib/amd64 -Dorg.lwjgl.librarypath=build/tmp/functionalTest/testLaunchRunConfigs/gameDir"/>
         <option name="WORKING_DIRECTORY" value="build/tmp/functionalTest/testLaunchRunConfigs/gameDir"/>
         <method v="2">
             <option enabled="true" externalProjectPath="$PROJECT_DIR$" name="Gradle.BeforeRunTask" scriptParameters="" tasks="zomboidClasses" vmOptions=""/>

--- a/src/main/java/io/pzstorm/capsid/setup/VmParameter.java
+++ b/src/main/java/io/pzstorm/capsid/setup/VmParameter.java
@@ -100,8 +100,8 @@ public class VmParameter {
 	public String toString() {
 
 		String expOptions = String.join(" ", new String[]{
-				formatAdvancedRuntimeOption("UseConcMarkSweepGC", useConcMarkSweepGC),
-				formatAdvancedRuntimeOption("CreateMinidumpOnCrash", createMinidumpOnCrash),
+				formatAdvancedRuntimeOption("UseZGC", useConcMarkSweepGC),
+				formatAdvancedRuntimeOption("CreateCoredumpOnCrash", createMinidumpOnCrash),
 				formatAdvancedRuntimeOption("OmitStackTraceInFastThrow", omitStackTraceInFastThrow)
 		});
 		StringBuilder sb = new StringBuilder();

--- a/src/test/java/io/pzstorm/capsid/setup/VmParameterTest.java
+++ b/src/test/java/io/pzstorm/capsid/setup/VmParameterTest.java
@@ -119,7 +119,7 @@ class VmParameterTest extends PluginUnitTest {
 
 		String delimiter = VmParameter.getPathDelimiter();
 		String expected = "-Ddebug -Dzomboid.steam=0 -Dzomboid.znetlog=0 " +
-				"-XX:-UseConcMarkSweepGC -XX:-CreateMinidumpOnCrash " +
+				"-XX:-UseZGC -XX:-CreateCoredumpOnCrash " +
 				"-XX:-OmitStackTraceInFastThrow -Xms250m -Xmx4096m " +
 				"-Djava.library.path=/home/libs/java" + delimiter + "/home/java/libs " +
 				"-Dorg.lwjgl.librarypath=/home/libs/lwjgl1" + delimiter + "/home/lwjgl/libs";


### PR DESCRIPTION
ConcMarkSweepGC is deprecated post Java 1.9. Since Capsid uses JDK15 at minimum, it was giving me problems. Also, CreateMinidumpOnCrash was deprecated too so I replaced it with coredump.